### PR TITLE
Fix: Make useScreenSize hook SSR-safe

### DIFF
--- a/src/hooks/useScreenSize.tsx
+++ b/src/hooks/useScreenSize.tsx
@@ -1,11 +1,29 @@
 import { useEffect, useState } from "react";
 
 export const useScreenSize = () => {
-  const [height, setHeight] = useState(window.innerHeight);
-  const detectHeight = () => setHeight(window.innerHeight);
+  // Initialize height to 0 for SSR safety
+  const [height, setHeight] = useState(0);
+
+  // Debounced resize handler
+  const detectHeight = () => {
+    if (typeof window !== "undefined") {
+      setHeight(window.innerHeight);
+    }
+  };
+
   useEffect(() => {
-    window.addEventListener("resize", detectHeight);
-    return () => window.removeEventListener("resize", detectHeight);
-  }, [height]);
+    // Set initial height on client-side
+    if (typeof window !== "undefined") {
+      setHeight(window.innerHeight);
+    }
+
+    // Add event listener only on client-side
+    if (typeof window !== "undefined") {
+      window.addEventListener("resize", detectHeight);
+      // Cleanup function to remove event listener
+      return () => window.removeEventListener("resize", detectHeight);
+    }
+  }, []); // Empty dependency array ensures this effect runs only once on mount and unmount
+
   return height;
 };

--- a/src/hooks/useScreenSize.tsx
+++ b/src/hooks/useScreenSize.tsx
@@ -4,25 +4,25 @@ export const useScreenSize = () => {
   // Initialize height to 0 for SSR safety
   const [height, setHeight] = useState(0);
 
-  // Debounced resize handler
-  const detectHeight = () => {
-    if (typeof window !== "undefined") {
-      setHeight(window.innerHeight);
-    }
-  };
-
   useEffect(() => {
-    // Set initial height on client-side
+    // All window interactions should be guarded
     if (typeof window !== "undefined") {
-      setHeight(window.innerHeight);
-    }
+      // Define detectHeight *inside* useEffect to ensure the same reference
+      const detectHeight = () => {
+        setHeight(window.innerHeight);
+      };
 
-    // Add event listener only on client-side
-    if (typeof window !== "undefined") {
+      // Set initial height on client-side
+      setHeight(window.innerHeight);
+
+      // Add event listener
       window.addEventListener("resize", detectHeight);
+
       // Cleanup function to remove event listener
       return () => window.removeEventListener("resize", detectHeight);
     }
+    // If window is not defined (e.g., during SSR), return a no-op cleanup function
+    return () => {};
   }, []); // Empty dependency array ensures this effect runs only once on mount and unmount
 
   return height;


### PR DESCRIPTION
Ensures that the useScreenSize hook does not attempt to access `window` object properties or methods during server-side rendering or at build time.

Changes:
- Initialized `height` state to `0`.
- Moved initial height detection using `window.innerHeight` into a `useEffect` hook that only runs on the client-side.
- Ensured `window.addEventListener` and `window.removeEventListener` are only called client-side.
- Optimized `useEffect` dependency array to `[]` for the event listener setup, as it only needs to run once on mount and clean up on unmount.

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 기타
