### PR TITLE
Add global page filter controls with UI sheet and CSS variables

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -13,134 +13,135 @@ import { Header } from "@/shared/ui/header";
 import { classNames } from "@/shared/utils/classnames";
 
 const displayFont = Space_Grotesk({
-	subsets: ["latin"],
-	variable: "--font-display",
+  subsets: ["latin"],
+  variable: "--font-display",
 });
 
 const bodyFont = Noto_Sans_KR({
-	subsets: ["latin"],
-	variable: "--font-body",
+  subsets: ["latin"],
+  variable: "--font-body",
 });
 
 export const metadata: Metadata = {
-	metadataBase: new URL(
-		process.env.VERCEL_URL
-			? `https://${process.env.VERCEL_URL}`
-			: "https://localhost:3000",
-	),
-	title: {
-		default: "Manjoong Kim | Frontend Portfolio",
-		template: "%s | Manjoong Kim",
-	},
-	description:
-		"Frontend developer portfolio focused on product UX, modern web architecture, and performance-aware implementation.",
-	applicationName: "Manjoong Kim Portfolio",
-	keywords: [
-		"Frontend Developer",
-		"Next.js",
-		"React",
-		"Portfolio",
-		"TypeScript",
-	],
-	authors: [{ name: "Manjoong Kim" }],
-	creator: "Manjoong Kim",
-	manifest: "/icon/manifest.json",
-	openGraph: {
-		title: "Manjoong Kim | Frontend Portfolio",
-		description:
-			"Portfolio showcasing frontend projects, interaction design, and engineering outcomes.",
-		url: "https://next-portfolio-ringring.vercel.app",
-		siteName: "Manjoong Kim Portfolio",
-		type: "website",
-		locale: "ko_KR",
-		images: [
-			{
-				url: "/icon/ms-icon-150x150.png",
-				width: 150,
-				height: 150,
-			},
-		],
-	},
-	twitter: {
-		card: "summary_large_image",
-		title: "Manjoong Kim | Frontend Portfolio",
-		description:
-			"Modern frontend case studies and product-driven engineering work.",
-		images: ["/icon/ms-icon-150x150.png"],
-	},
-	robots: {
-		index: true,
-		follow: true,
-	},
-	icons: {
-		icon: [{ url: "/favicon.ico" }],
-		apple: [
-			{ url: "/icon/apple-icon-57x57.png", sizes: "57x57" },
-			{ url: "/icon/apple-icon-60x60.png", sizes: "60x60" },
-			{ url: "/icon/apple-icon-72x72.png" },
-			{ url: "/icon/apple-icon-76x76.png" },
-			{ url: "/icon/apple-icon-120x120.png" },
-			{ url: "/icon/apple-icon-144x144.png" },
-			{ url: "/icon/apple-icon-152x152.png" },
-			{ url: "/icon/apple-icon-180x180.png" },
-		],
-		other: [
-			{ url: "/icon/favicon-16x16.png" },
-			{ url: "/icon/favicon-32x32.png" },
-			{ url: "/icon/favicon-96x96.png" },
-		],
-	},
+  metadataBase: new URL(
+    process.env.VERCEL_URL
+      ? `https://${process.env.VERCEL_URL}`
+      : "https://localhost:3000",
+  ),
+  title: {
+    default: "Manjoong Kim | Frontend Portfolio",
+    template: "%s | Manjoong Kim",
+  },
+  description:
+    "Frontend developer portfolio focused on product UX, modern web architecture, and performance-aware implementation.",
+  applicationName: "Manjoong Kim Portfolio",
+  keywords: [
+    "Frontend Developer",
+    "Next.js",
+    "React",
+    "Portfolio",
+    "TypeScript",
+  ],
+  authors: [{ name: "Manjoong Kim" }],
+  creator: "Manjoong Kim",
+  manifest: "/icon/manifest.json",
+  openGraph: {
+    title: "Manjoong Kim | Frontend Portfolio",
+    description:
+      "Portfolio showcasing frontend projects, interaction design, and engineering outcomes.",
+    url: "https://next-portfolio-ringring.vercel.app",
+    siteName: "Manjoong Kim Portfolio",
+    type: "website",
+    locale: "ko_KR",
+    images: [
+      {
+        url: "/icon/ms-icon-150x150.png",
+        width: 150,
+        height: 150,
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Manjoong Kim | Frontend Portfolio",
+    description:
+      "Modern frontend case studies and product-driven engineering work.",
+    images: ["/icon/ms-icon-150x150.png"],
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
+  icons: {
+    icon: [{ url: "/favicon.ico" }],
+    apple: [
+      { url: "/icon/apple-icon-57x57.png", sizes: "57x57" },
+      { url: "/icon/apple-icon-60x60.png", sizes: "60x60" },
+      { url: "/icon/apple-icon-72x72.png" },
+      { url: "/icon/apple-icon-76x76.png" },
+      { url: "/icon/apple-icon-120x120.png" },
+      { url: "/icon/apple-icon-144x144.png" },
+      { url: "/icon/apple-icon-152x152.png" },
+      { url: "/icon/apple-icon-180x180.png" },
+    ],
+    other: [
+      { url: "/icon/favicon-16x16.png" },
+      { url: "/icon/favicon-32x32.png" },
+      { url: "/icon/favicon-96x96.png" },
+    ],
+  },
 };
 
 export function generateStaticParams() {
-	return routing.locales.map((locale) => ({ locale }));
+  return routing.locales.map((locale) => ({ locale }));
 }
 
 export default async function LocaleLayout({
-	children,
-	modal,
-	params,
+  children,
+  modal,
+  params,
 }: LayoutProps<"/[locale]"> & {
-	modal: React.ReactNode;
+  modal: React.ReactNode;
 }) {
-	const { locale } = await params;
+  const { locale } = await params;
 
-	// Ensure that the incoming `locale` is valid
-	if (!routing.locales.includes(locale as "en" | "ko")) {
-		notFound();
-	}
+  // Ensure that the incoming `locale` is valid
+  if (!routing.locales.includes(locale as "en" | "ko")) {
+    notFound();
+  }
 
-	// Providing all messages to the client
-	// side is the easiest way to get started
-	const messages = await getMessages();
+  // Providing all messages to the client
+  // side is the easiest way to get started
+  const messages = await getMessages();
 
-	return (
-		<html lang={locale} suppressHydrationWarning>
-			<body
-				className={classNames(
-					displayFont.variable,
-					bodyFont.variable,
-					"antialiased relative flex size-full min-h-screen flex-col overflow-x-hidden bg-background text-foreground",
-				)}
-			>
-				<div className="pointer-events-none fixed inset-0 -z-10 bg-[radial-gradient(circle_at_15%_15%,color-mix(in_oklch,var(--color-highlight),transparent_84%),transparent_42%),radial-gradient(circle_at_85%_0%,color-mix(in_oklch,var(--color-surface-strong),transparent_86%),transparent_48%),linear-gradient(180deg,var(--background),color-mix(in_oklch,var(--background),black_5%))]" />
-				<NextIntlClientProvider messages={messages}>
-					<ThemeProvider
-						attribute="class"
-						defaultTheme="system"
-						enableSystem
-						disableTransitionOnChange
-					>
-						<div className="flex h-full grow flex-col">
-							<Header />
-							{children}
-							{modal}
-							<Footer />
-						</div>
-					</ThemeProvider>
-				</NextIntlClientProvider>
-			</body>
-			<GoogleAnalytics gaId={env.NEXT_PUBLIC_GOOGLE_ANALYTICS} />
-		</html>
-	);
+  return (
+    <html lang={locale} suppressHydrationWarning>
+      <body
+        className={classNames(
+          displayFont.variable,
+          bodyFont.variable,
+          "antialiased relative flex size-full min-h-screen flex-col overflow-x-hidden bg-background text-foreground",
+        )}
+      >
+        <div className="pointer-events-none fixed inset-0 -z-10 bg-[radial-gradient(circle_at_15%_15%,color-mix(in_oklch,var(--color-highlight),transparent_84%),transparent_42%),radial-gradient(circle_at_85%_0%,color-mix(in_oklch,var(--color-surface-strong),transparent_86%),transparent_48%),linear-gradient(180deg,var(--background),color-mix(in_oklch,var(--background),black_5%))]" />
+        <div className="page-filter-layer pointer-events-none fixed inset-0 z-30" />
+        <NextIntlClientProvider messages={messages}>
+          <ThemeProvider
+            attribute="class"
+            defaultTheme="system"
+            enableSystem
+            disableTransitionOnChange
+          >
+            <div className="flex h-full grow flex-col">
+              <Header />
+              {children}
+              {modal}
+              <Footer />
+            </div>
+          </ThemeProvider>
+        </NextIntlClientProvider>
+      </body>
+      <GoogleAnalytics gaId={env.NEXT_PUBLIC_GOOGLE_ANALYTICS} />
+    </html>
+  );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,167 +4,182 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
-	--background: oklch(0.985 0.004 255);
-	--foreground: oklch(0.215 0.02 258);
-	--card: oklch(0.995 0.003 255);
-	--card-foreground: oklch(0.215 0.02 258);
-	--popover: oklch(0.995 0.003 255);
-	--popover-foreground: oklch(0.215 0.02 258);
-	--primary: oklch(0.56 0.2 259);
-	--primary-foreground: oklch(0.988 0.003 255);
-	--secondary: oklch(0.95 0.01 255);
-	--secondary-foreground: oklch(0.255 0.02 260);
-	--muted: oklch(0.954 0.008 255);
-	--muted-foreground: oklch(0.52 0.025 257);
-	--accent: oklch(0.89 0.05 255);
-	--accent-foreground: oklch(0.24 0.02 259);
-	--destructive: oklch(0.577 0.245 27.325);
-	--destructive-foreground: oklch(0.577 0.245 27.325);
-	--border: oklch(0.89 0.014 255);
-	--input: oklch(0.89 0.014 255);
-	--ring: oklch(0.65 0.14 259);
-	--surface: oklch(0.988 0.005 255);
-	--surface-strong: oklch(0.94 0.03 258);
-	--highlight: oklch(0.74 0.18 190);
-	--hero-title: linear-gradient(
-		110deg,
-		oklch(0.31 0.08 259) 0%,
-		oklch(0.51 0.2 259) 52%,
-		oklch(0.73 0.17 192) 100%
-	);
-	--radius: 0.625rem;
+  --background: oklch(0.985 0.004 255);
+  --foreground: oklch(0.215 0.02 258);
+  --card: oklch(0.995 0.003 255);
+  --card-foreground: oklch(0.215 0.02 258);
+  --popover: oklch(0.995 0.003 255);
+  --popover-foreground: oklch(0.215 0.02 258);
+  --primary: oklch(0.56 0.2 259);
+  --primary-foreground: oklch(0.988 0.003 255);
+  --secondary: oklch(0.95 0.01 255);
+  --secondary-foreground: oklch(0.255 0.02 260);
+  --muted: oklch(0.954 0.008 255);
+  --muted-foreground: oklch(0.52 0.025 257);
+  --accent: oklch(0.89 0.05 255);
+  --accent-foreground: oklch(0.24 0.02 259);
+  --destructive: oklch(0.577 0.245 27.325);
+  --destructive-foreground: oklch(0.577 0.245 27.325);
+  --border: oklch(0.89 0.014 255);
+  --input: oklch(0.89 0.014 255);
+  --ring: oklch(0.65 0.14 259);
+  --surface: oklch(0.988 0.005 255);
+  --surface-strong: oklch(0.94 0.03 258);
+  --highlight: oklch(0.74 0.18 190);
+  --hero-title: linear-gradient(
+    110deg,
+    oklch(0.31 0.08 259) 0%,
+    oklch(0.51 0.2 259) 52%,
+    oklch(0.73 0.17 192) 100%
+  );
+  --radius: 0.625rem;
+  --page-filter-brightness: 102%;
+  --page-filter-contrast: 108%;
+  --page-filter-saturation: 135%;
+  --page-filter-hue: 0deg;
 }
 
 .dark {
-	--background: oklch(0.17 0.014 258);
-	--foreground: oklch(0.94 0.015 255);
-	--card: oklch(0.22 0.016 258);
-	--card-foreground: oklch(0.94 0.015 255);
-	--popover: oklch(0.2 0.016 258);
-	--popover-foreground: oklch(0.94 0.015 255);
-	--primary: oklch(0.72 0.17 192);
-	--primary-foreground: oklch(0.19 0.02 258);
-	--secondary: oklch(0.28 0.018 258);
-	--secondary-foreground: oklch(0.91 0.015 255);
-	--muted: oklch(0.26 0.015 258);
-	--muted-foreground: oklch(0.72 0.02 255);
-	--accent: oklch(0.33 0.03 255);
-	--accent-foreground: oklch(0.92 0.015 255);
-	--destructive: oklch(0.396 0.141 25.723);
-	--destructive-foreground: oklch(0.637 0.237 25.331);
-	--border: oklch(0.33 0.014 258);
-	--input: oklch(0.33 0.014 258);
-	--ring: oklch(0.68 0.16 190);
-	--surface: oklch(0.21 0.015 258);
-	--surface-strong: oklch(0.29 0.03 255);
-	--highlight: oklch(0.72 0.17 192);
-	--hero-title: linear-gradient(
-		105deg,
-		oklch(0.94 0.03 255) 0%,
-		oklch(0.78 0.17 192) 42%,
-		oklch(0.66 0.18 259) 100%
-	);
+  --background: oklch(0.17 0.014 258);
+  --foreground: oklch(0.94 0.015 255);
+  --card: oklch(0.22 0.016 258);
+  --card-foreground: oklch(0.94 0.015 255);
+  --popover: oklch(0.2 0.016 258);
+  --popover-foreground: oklch(0.94 0.015 255);
+  --primary: oklch(0.72 0.17 192);
+  --primary-foreground: oklch(0.19 0.02 258);
+  --secondary: oklch(0.28 0.018 258);
+  --secondary-foreground: oklch(0.91 0.015 255);
+  --muted: oklch(0.26 0.015 258);
+  --muted-foreground: oklch(0.72 0.02 255);
+  --accent: oklch(0.33 0.03 255);
+  --accent-foreground: oklch(0.92 0.015 255);
+  --destructive: oklch(0.396 0.141 25.723);
+  --destructive-foreground: oklch(0.637 0.237 25.331);
+  --border: oklch(0.33 0.014 258);
+  --input: oklch(0.33 0.014 258);
+  --ring: oklch(0.68 0.16 190);
+  --surface: oklch(0.21 0.015 258);
+  --surface-strong: oklch(0.29 0.03 255);
+  --highlight: oklch(0.72 0.17 192);
+  --hero-title: linear-gradient(
+    105deg,
+    oklch(0.94 0.03 255) 0%,
+    oklch(0.78 0.17 192) 42%,
+    oklch(0.66 0.18 259) 100%
+  );
 }
 
 @theme inline {
-	--color-background: var(--background);
-	--color-foreground: var(--foreground);
-	--color-card: var(--card);
-	--color-card-foreground: var(--card-foreground);
-	--color-popover: var(--popover);
-	--color-popover-foreground: var(--popover-foreground);
-	--color-primary: var(--primary);
-	--color-primary-foreground: var(--primary-foreground);
-	--color-secondary: var(--secondary);
-	--color-secondary-foreground: var(--secondary-foreground);
-	--color-muted: var(--muted);
-	--color-muted-foreground: var(--muted-foreground);
-	--color-accent: var(--accent);
-	--color-accent-foreground: var(--accent-foreground);
-	--color-destructive: var(--destructive);
-	--color-destructive-foreground: var(--destructive-foreground);
-	--color-border: var(--border);
-	--color-input: var(--input);
-	--color-ring: var(--ring);
-	--color-surface: var(--surface);
-	--color-surface-strong: var(--surface-strong);
-	--color-highlight: var(--highlight);
-	--radius-sm: calc(var(--radius) - 4px);
-	--radius-md: calc(var(--radius) - 2px);
-	--radius-lg: var(--radius);
-	--radius-xl: calc(var(--radius) + 4px);
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-surface: var(--surface);
+  --color-surface-strong: var(--surface-strong);
+  --color-highlight: var(--highlight);
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
 }
 
 @layer base {
-	* {
-		@apply border-border outline-ring/50;
-	}
-	body {
-		font-family: var(--font-body), sans-serif;
-		@apply bg-background text-foreground;
-		background-image:
-			radial-gradient(
-				1100px circle at 4% -10%,
-				color-mix(in oklch, var(--color-highlight), transparent 88%),
-				transparent 62%
-			),
-			radial-gradient(
-				900px circle at 100% 0%,
-				color-mix(in oklch, var(--color-primary), transparent 90%),
-				transparent 58%
-			);
-		min-height: 100vh;
-	}
+  * {
+    @apply border-border outline-ring/50;
+  }
+  body {
+    font-family: var(--font-body), sans-serif;
+    @apply bg-background text-foreground;
+    background-image:
+      radial-gradient(
+        1100px circle at 4% -10%,
+        color-mix(in oklch, var(--color-highlight), transparent 88%),
+        transparent 62%
+      ),
+      radial-gradient(
+        900px circle at 100% 0%,
+        color-mix(in oklch, var(--color-primary), transparent 90%),
+        transparent 58%
+      );
+    min-height: 100vh;
+  }
 
-	h1,
-	h2,
-	h3,
-	h4 {
-		font-family: var(--font-display), var(--font-body), sans-serif;
-		letter-spacing: -0.02em;
-	}
+  h1,
+  h2,
+  h3,
+  h4 {
+    font-family: var(--font-display), var(--font-body), sans-serif;
+    letter-spacing: -0.02em;
+  }
 }
 
 @layer utilities {
-	.glass-panel {
-		background: color-mix(in oklch, var(--color-surface), transparent 18%);
-		border: 1px solid color-mix(in oklch, var(--color-border), transparent 18%);
-		box-shadow:
-			0 20px 60px -40px
-			color-mix(in oklch, var(--color-primary), transparent 50%),
-			0 8px 20px -18px
-			color-mix(in oklch, var(--color-highlight), transparent 65%);
-		backdrop-filter: blur(10px);
-	}
+  .glass-panel {
+    background: color-mix(in oklch, var(--color-surface), transparent 18%);
+    border: 1px solid color-mix(in oklch, var(--color-border), transparent 18%);
+    box-shadow:
+      0 20px 60px -40px
+        color-mix(in oklch, var(--color-primary), transparent 50%),
+      0 8px 20px -18px
+        color-mix(in oklch, var(--color-highlight), transparent 65%);
+    backdrop-filter: blur(10px);
+  }
 
-	.section-shell {
-		@apply w-full max-w-6xl px-4 md:px-8;
-	}
+  .section-shell {
+    @apply w-full max-w-6xl px-4 md:px-8;
+  }
 
-	.text-gradient-hero {
-		background: var(--hero-title);
-		-webkit-background-clip: text;
-		background-clip: text;
-		color: transparent;
-	}
+  .page-filter-layer {
+    backdrop-filter: brightness(var(--page-filter-brightness, 102%))
+      contrast(var(--page-filter-contrast, 108%))
+      saturate(var(--page-filter-saturation, 135%))
+      hue-rotate(var(--page-filter-hue, 0deg));
+    -webkit-backdrop-filter: brightness(var(--page-filter-brightness, 102%))
+      contrast(var(--page-filter-contrast, 108%))
+      saturate(var(--page-filter-saturation, 135%))
+      hue-rotate(var(--page-filter-hue, 0deg));
+  }
+
+  .text-gradient-hero {
+    background: var(--hero-title);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+  }
 }
 
 /* View Transition API Support */
 @view-transition {
-	navigation: auto;
+  navigation: auto;
 }
 
 /* Route-level fade/blur */
 ::view-transition-old(.vt-route),
 ::view-transition-old(route),
 ::view-transition-old(vt-route) {
-	animation: route-fade-out 0.35s ease-out forwards;
+  animation: route-fade-out 0.35s ease-out forwards;
 }
 
 ::view-transition-new(.vt-route),
 ::view-transition-new(route),
 ::view-transition-new(vt-route) {
-	animation: route-fade-in 0.45s ease-out forwards;
+  animation: route-fade-in 0.45s ease-out forwards;
 }
 
 /* Modal transitions */
@@ -174,19 +189,19 @@
 ::view-transition-old(.vt-modal-content),
 ::view-transition-old(vt-modal-content),
 ::view-transition-old(project-modal-content) {
-	animation: modal-fade-out 0.2s ease-out forwards;
+  animation: modal-fade-out 0.2s ease-out forwards;
 }
 
 ::view-transition-new(.vt-modal),
 ::view-transition-new(vt-modal),
 ::view-transition-new(project-modal) {
-	animation: modal-fade-in 0.35s ease-out forwards;
+  animation: modal-fade-in 0.35s ease-out forwards;
 }
 
 ::view-transition-new(.vt-modal-content),
 ::view-transition-new(vt-modal-content),
 ::view-transition-new(project-modal-content) {
-	animation: modal-pop-in 0.35s ease-out forwards;
+  animation: modal-pop-in 0.35s ease-out forwards;
 }
 
 /* Project media/title transitions */
@@ -196,25 +211,25 @@
 ::view-transition-new(.vt-project-image),
 ::view-transition-new(vt-project-image),
 ::view-transition-new(project-image) {
-	height: 100%;
-	overflow: clip;
-	animation-duration: 0.5s;
-	animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-	mix-blend-mode: normal;
-	z-index: 1;
+  height: 100%;
+  overflow: clip;
+  animation-duration: 0.5s;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  mix-blend-mode: normal;
+  z-index: 1;
 }
 
 ::view-transition-new(.vt-project-image),
 ::view-transition-new(vt-project-image),
 ::view-transition-new(project-image) {
-	animation-name: media-zoom-in;
-	z-index: 2;
+  animation-name: media-zoom-in;
+  z-index: 2;
 }
 
 ::view-transition-old(.vt-project-image),
 ::view-transition-old(vt-project-image),
 ::view-transition-old(project-image) {
-	animation-name: media-shrink-out;
+  animation-name: media-shrink-out;
 }
 
 ::view-transition-old(.vt-project-title),
@@ -223,171 +238,171 @@
 ::view-transition-new(.vt-project-title),
 ::view-transition-new(vt-project-title),
 ::view-transition-new(project-title) {
-	animation-duration: 0.45s;
-	animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-	z-index: 1;
+  animation-duration: 0.45s;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  z-index: 1;
 }
 
 ::view-transition-new(.vt-project-title),
 ::view-transition-new(vt-project-title),
 ::view-transition-new(project-title) {
-	animation-name: fade-in;
-	z-index: 2;
+  animation-name: fade-in;
+  z-index: 2;
 }
 
 ::view-transition-old(.vt-project-title),
 ::view-transition-old(vt-project-title),
 ::view-transition-old(project-title) {
-	animation-name: fade-out;
+  animation-name: fade-out;
 }
 
 @keyframes fade-in {
-	from {
-		opacity: 0;
-	}
-	to {
-		opacity: 1;
-	}
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 @keyframes fade-out {
-	from {
-		opacity: 1;
-	}
-	to {
-		opacity: 0;
-	}
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
 }
 
 @keyframes slide-in {
-	from {
-		transform: translateY(8px) scale(0.98);
-	}
-	to {
-		transform: translateY(0) scale(1);
-	}
+  from {
+    transform: translateY(8px) scale(0.98);
+  }
+  to {
+    transform: translateY(0) scale(1);
+  }
 }
 
 @keyframes slide-out {
-	from {
-		transform: translateY(0) scale(1);
-	}
-	to {
-		transform: translateY(-8px) scale(0.98);
-	}
+  from {
+    transform: translateY(0) scale(1);
+  }
+  to {
+    transform: translateY(-8px) scale(0.98);
+  }
 }
 
 @keyframes modal-fade-in {
-	from {
-		opacity: 0;
-		transform: translateY(12px) scale(0.98);
-	}
-	to {
-		opacity: 1;
-		transform: translateY(0) scale(1);
-	}
+  from {
+    opacity: 0;
+    transform: translateY(12px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
 }
 
 @keyframes modal-fade-out {
-	from {
-		opacity: 1;
-		transform: translateY(0) scale(1);
-	}
-	to {
-		opacity: 0;
-		transform: translateY(-8px) scale(0.98);
-	}
+  from {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(-8px) scale(0.98);
+  }
 }
 
 @keyframes modal-pop-in {
-	from {
-		opacity: 0;
-		transform: translateY(10px) scale(0.96);
-	}
-	to {
-		opacity: 1;
-		transform: translateY(0) scale(1);
-	}
+  from {
+    opacity: 0;
+    transform: translateY(10px) scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
 }
 
 @keyframes route-fade-in {
-	from {
-		opacity: 0;
-		transform: translateY(6px);
-	}
-	to {
-		opacity: 1;
-		transform: translateY(0);
-	}
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 @keyframes route-fade-out {
-	from {
-		opacity: 1;
-		transform: translateY(0);
-	}
-	to {
-		opacity: 0;
-		transform: translateY(-6px);
-	}
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
 }
 
 @keyframes media-zoom-in {
-	from {
-		transform: scale(0.98);
-	}
-	to {
-		transform: scale(1);
-	}
+  from {
+    transform: scale(0.98);
+  }
+  to {
+    transform: scale(1);
+  }
 }
 
 @keyframes media-shrink-out {
-	from {
-		transform: scale(1);
-	}
-	to {
-		transform: scale(0.98);
-	}
+  from {
+    transform: scale(1);
+  }
+  to {
+    transform: scale(0.98);
+  }
 }
 
 /* Modal and Dialog Styles */
 dialog {
-	border: none;
-	padding: 0;
-	max-width: 100vw;
-	max-height: 100vh;
+  border: none;
+  padding: 0;
+  max-width: 100vw;
+  max-height: 100vh;
 }
 
 dialog::backdrop {
-	background: color-mix(in oklch, var(--color-background), black 72%);
-	backdrop-filter: blur(8px);
+  background: color-mix(in oklch, var(--color-background), black 72%);
+  backdrop-filter: blur(8px);
 }
 
 /* Hide content behind modal during view transition */
 @supports (view-transition-name: none) {
-	html:has(dialog[open]) {
-		overflow: hidden;
-	}
+  html:has(dialog[open]) {
+    overflow: hidden;
+  }
 
-	/* Ensure modal appears above everything during transition */
-	dialog[open] {
-		z-index: 9999;
-	}
+  /* Ensure modal appears above everything during transition */
+  dialog[open] {
+    z-index: 9999;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
-	*,
-	*::before,
-	*::after {
-		animation-duration: 0.01ms !important;
-		animation-iteration-count: 1 !important;
-		transition-duration: 0.01ms !important;
-		scroll-behavior: auto !important;
-	}
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 
-	::view-transition-old(*),
-	::view-transition-new(*) {
-		animation: none !important;
-		filter: none !important;
-	}
+  ::view-transition-old(*),
+  ::view-transition-new(*) {
+    animation: none !important;
+    filter: none !important;
+  }
 }

--- a/src/shared/ui/footer.tsx
+++ b/src/shared/ui/footer.tsx
@@ -1,24 +1,76 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
 import { Link } from "@/i18n/routing";
-import { Mail } from "lucide-react";
+import { Mail, SlidersHorizontal, X } from "lucide-react";
 import { GithubIcon, LinkedinIcon } from "./icon/brand";
 import { ModeToggle } from "./theme-toggle";
 import { useTranslations } from "next-intl";
 
+const DEFAULT_FILTER = {
+  brightness: 102,
+  contrast: 108,
+  saturation: 135,
+  hue: 0,
+};
+
 export function Footer() {
   const t = useTranslations("Footer");
 
+  const [isSheetOpen, setIsSheetOpen] = useState(false);
+  const [brightness, setBrightness] = useState(DEFAULT_FILTER.brightness);
+  const [contrast, setContrast] = useState(DEFAULT_FILTER.contrast);
+  const [saturation, setSaturation] = useState(DEFAULT_FILTER.saturation);
+  const [hue, setHue] = useState(DEFAULT_FILTER.hue);
+
+  useEffect(() => {
+    const root = document.documentElement;
+
+    root.style.setProperty("--page-filter-brightness", `${brightness}%`);
+    root.style.setProperty("--page-filter-contrast", `${contrast}%`);
+    root.style.setProperty("--page-filter-saturation", `${saturation}%`);
+    root.style.setProperty("--page-filter-hue", `${hue}deg`);
+  }, [brightness, contrast, saturation, hue]);
+
+  const hasCustomFilter = useMemo(
+    () =>
+      brightness !== DEFAULT_FILTER.brightness ||
+      contrast !== DEFAULT_FILTER.contrast ||
+      saturation !== DEFAULT_FILTER.saturation ||
+      hue !== DEFAULT_FILTER.hue,
+    [brightness, contrast, saturation, hue],
+  );
+
+  const resetFilter = () => {
+    setBrightness(DEFAULT_FILTER.brightness);
+    setContrast(DEFAULT_FILTER.contrast);
+    setSaturation(DEFAULT_FILTER.saturation);
+    setHue(DEFAULT_FILTER.hue);
+  };
+
   return (
-    <footer className="mt-auto border-t border-border/70 py-8">
+    <footer className="relative mt-auto border-t border-border/70 py-8">
       <div className="section-shell mx-auto">
         <div className="glass-panel flex flex-col items-center justify-between gap-5 rounded-2xl px-4 py-5 md:flex-row md:px-6">
           <div className="flex flex-col items-center md:items-start">
             <p className="text-sm text-muted-foreground">
-              © {new Date().getFullYear()} Manjoong Kim. {t("allRightsReserved")}
+              © {new Date().getFullYear()} Manjoong Kim.{" "}
+              {t("allRightsReserved")}
             </p>
-            <p className="mt-1 text-xs text-muted-foreground/90">{t("builtWith")}</p>
+            <p className="mt-1 text-xs text-muted-foreground/90">
+              {t("builtWith")}
+            </p>
           </div>
 
           <div className="flex items-center gap-2">
+            <button
+              onClick={() => setIsSheetOpen(true)}
+              className="inline-flex h-9 items-center justify-center gap-1 rounded-lg border border-border/70 bg-background/50 px-3 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+              aria-label="Open page filter controls"
+            >
+              <SlidersHorizontal size={14} />
+              Filter
+            </button>
             <Link
               href="https://github.com/Ring-wdr"
               target="_blank"
@@ -48,6 +100,101 @@ export function Footer() {
           </div>
         </div>
       </div>
+
+      {isSheetOpen && (
+        <>
+          <button
+            className="fixed inset-0 z-40 bg-black/30 backdrop-blur-[1px]"
+            onClick={() => setIsSheetOpen(false)}
+            aria-label="Close filter sheet"
+          />
+          <div className="fixed inset-x-0 bottom-0 z-50 mx-auto w-full max-w-3xl rounded-t-2xl border border-border/70 bg-background/90 p-4 shadow-2xl backdrop-blur-md md:left-1/2 md:max-w-2xl md:-translate-x-1/2">
+            <div className="mb-4 flex items-center justify-between">
+              <div>
+                <p className="text-sm font-semibold">Global Backdrop Filter</p>
+                <p className="text-xs text-muted-foreground">
+                  실시간으로 전체 페이지 필터를 조절합니다.
+                </p>
+              </div>
+              <button
+                onClick={() => setIsSheetOpen(false)}
+                className="rounded-md p-1 text-muted-foreground transition-colors hover:text-foreground"
+                aria-label="Close"
+              >
+                <X size={18} />
+              </button>
+            </div>
+
+            <div className="grid gap-3 md:grid-cols-2">
+              <label className="space-y-1 text-xs text-muted-foreground">
+                <span>Brightness ({brightness}%)</span>
+                <input
+                  className="w-full accent-primary"
+                  type="range"
+                  min={70}
+                  max={160}
+                  value={brightness}
+                  onChange={(event) =>
+                    setBrightness(Number(event.target.value))
+                  }
+                />
+              </label>
+              <label className="space-y-1 text-xs text-muted-foreground">
+                <span>Contrast ({contrast}%)</span>
+                <input
+                  className="w-full accent-primary"
+                  type="range"
+                  min={70}
+                  max={160}
+                  value={contrast}
+                  onChange={(event) => setContrast(Number(event.target.value))}
+                />
+              </label>
+              <label className="space-y-1 text-xs text-muted-foreground">
+                <span>Saturation ({saturation}%)</span>
+                <input
+                  className="w-full accent-primary"
+                  type="range"
+                  min={60}
+                  max={220}
+                  value={saturation}
+                  onChange={(event) =>
+                    setSaturation(Number(event.target.value))
+                  }
+                />
+              </label>
+              <label className="space-y-1 text-xs text-muted-foreground">
+                <span>Hue Rotate ({hue}deg)</span>
+                <input
+                  className="w-full accent-primary"
+                  type="range"
+                  min={-180}
+                  max={180}
+                  value={hue}
+                  onChange={(event) => setHue(Number(event.target.value))}
+                />
+              </label>
+            </div>
+
+            <div className="mt-4 flex items-center justify-end gap-2">
+              {hasCustomFilter && (
+                <button
+                  onClick={resetFilter}
+                  className="rounded-lg border border-border/70 px-3 py-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+                >
+                  Reset
+                </button>
+              )}
+              <button
+                onClick={() => setIsSheetOpen(false)}
+                className="rounded-lg bg-primary px-3 py-1.5 text-xs text-primary-foreground"
+              >
+                Done
+              </button>
+            </div>
+          </div>
+        </>
+      )}
     </footer>
   );
 }


### PR DESCRIPTION
### Motivation
- Add a user-facing control to adjust a global backdrop filter (brightness/contrast/saturation/hue) for the whole page. 
- Surface a page-level filter layer to enable real-time visual adjustments without changing component internals. 

### Description
- Inserted a `div.page-filter-layer` into the root layout (`src/app/[locale]/layout.tsx`) so the global filter can be rendered above the background and behind content. 
- Added CSS custom properties `--page-filter-brightness`, `--page-filter-contrast`, `--page-filter-saturation`, and `--page-filter-hue` and a `.page-filter-layer` utility in `src/app/globals.css` that applies `backdrop-filter` using those variables. 
- Implemented client-side footer controls in `src/shared/ui/footer.tsx` (added `"use client"`) including a filter button, a slide-up sheet with range inputs for brightness/contrast/saturation/hue, persistence via root CSS properties, a reset action, and related icons/UI. 
- Minor formatting/indentation cleanups in `layout.tsx` and `globals.css` for consistent styling. 

### Testing
- Ran a TypeScript type check with `tsc --noEmit` and it succeeded. 
- Ran linting with `npm run lint` and there were no new issues. 
- Verified the production build with `next build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0f69f9bd083218bb54b70d0473e35)